### PR TITLE
Exposes a stop method to allow instances to stop rotation.

### DIFF
--- a/src/traqball.js
+++ b/src/traqball.js
@@ -201,6 +201,9 @@
             bindEvent(THIS.box, 'touchstart', startrotation);
 
             THIS.evHandlers = [startrotation, rotate, finishrotation];
+
+            // expose stopSlide
+            THIS.stop = hardStop;
         })();
 
 
@@ -336,6 +339,13 @@
                 stopSlide();
             }else{
                 requestAnimFrame(slide);
+            }
+        }
+
+        function hardStop(done) {
+            stopSlide();
+            if (done) {
+              setTimeout(done, 100);
             }
         }
 


### PR DESCRIPTION
To be called when user clicks the reset orientation icon within trinket. Will be used to solve trinketapp/3D-testing#21.